### PR TITLE
MM-813: Fixed the issue of wrong name shown in subscription when PR is moved from draft to ready for review

### DIFF
--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -224,7 +224,7 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 {{- else -}}
 #### {{.Event.GetPullRequest.GetTitle}}
 ##### {{template "eventRepoPullRequest" .Event}}
-#new-pull-request by {{template "user" .Event.GetSender}}
+#new-pull-request by {{template "user" .Event.PullRequest.User}}
 {{- if ne .Config.Style "skip-body" -}}
 {{- template "labels" dict "Labels" .Event.GetPullRequest.Labels "RepositoryURL" .Event.GetRepo.GetHTMLURL  }}
 {{- template "assignee" .Event.GetPullRequest }}


### PR DESCRIPTION
### Description
Fixed the issue of the wrong name shown in the subscription when PR is moved from draft to ready for review

### Screenshots
#### Existing
![Screenshot from 2024-08-26 17-33-26](https://github.com/user-attachments/assets/80e722d0-9583-4c15-85ff-141fa6361560)
#### Updated
![Screenshot from 2024-08-26 17-33-51](https://github.com/user-attachments/assets/c3b60c59-f04a-4247-b97c-709fbec389a5)

### What to test
- Create a subscription for a repo
- Create a PR with user B and mark it as `draft`
- Mark the PR as `ready for review` from user A
#### Expected
- `#new-pull-request` by B
#### Actual
- `#new-pull-request` by A